### PR TITLE
Maid 22 bad alloc

### DIFF
--- a/src/maidsafe/rudp/connection_manager.cc
+++ b/src/maidsafe/rudp/connection_manager.cc
@@ -72,14 +72,9 @@ ConnectionManager::ConnectionManager(std::shared_ptr<Transport> transport,
 ConnectionManager::~ConnectionManager() { Close(); }
 
 void ConnectionManager::Close() {
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    for (auto connection : connections_)
-      strand_.post(std::bind(&Connection::Close, connection));
-  }
-  // Ugly, but we must not reset dispatcher until he's done
-  while (multiplexer_->dispatcher_.use_count()) std::this_thread::yield();
   multiplexer_->dispatcher_.SetConnectionManager(nullptr);
+  for (auto& connection : connections_)
+    strand_.post(std::bind(&Connection::Close, connection));
 }
 
 void ConnectionManager::Connect(const NodeId& peer_id, const Endpoint& peer_endpoint,

--- a/src/maidsafe/rudp/core/dispatcher.cc
+++ b/src/maidsafe/rudp/core/dispatcher.cc
@@ -38,45 +38,25 @@ namespace rudp {
 
 namespace detail {
 
-Dispatcher::Dispatcher() : use_count_(std::make_shared<int>()),
-  connection_manager_(nullptr) {}
+Dispatcher::Dispatcher() : connection_manager_(nullptr) {}
 
 void Dispatcher::SetConnectionManager(ConnectionManager *connection_manager) {
-  std::lock_guard<decltype(mutex_)> guard(mutex_);
   connection_manager_ = std::move(connection_manager);
 }
 
 uint32_t Dispatcher::AddSocket(Socket* socket) {
-  auto in_use(use_count_);
-  ConnectionManager *connection_manager;
-  {
-    std::lock_guard<decltype(mutex_)> guard(mutex_);
-    connection_manager = connection_manager_;
-  }
-  return connection_manager ? connection_manager->AddSocket(socket) : 0;
+  return connection_manager_ ? connection_manager_->AddSocket(socket) : 0;
 }
 
 void Dispatcher::RemoveSocket(uint32_t id) {
-  auto in_use(use_count_);
-  ConnectionManager *connection_manager;
-  {
-    std::lock_guard<decltype(mutex_)> guard(mutex_);
-    connection_manager = connection_manager_;
-  }
-  if (connection_manager)
-    connection_manager->RemoveSocket(id);
+  if (connection_manager_)
+    connection_manager_->RemoveSocket(id);
 }
 
 void Dispatcher::HandleReceiveFrom(const asio::const_buffer& data,
                                    const ip::udp::endpoint& endpoint) {
-  auto in_use(use_count_);
-  ConnectionManager* connection_manager;
-  {
-    std::lock_guard<decltype(mutex_)> guard(mutex_);
-    connection_manager = connection_manager_;
-  }
-  if (connection_manager) {
-    Socket* socket(connection_manager->GetSocket(data, endpoint));
+  if (connection_manager_) {
+    Socket* socket(connection_manager_->GetSocket(data, endpoint));
     if (socket) {
       socket->HandleReceiveFrom(data, endpoint);
     }

--- a/src/maidsafe/rudp/core/dispatcher.h
+++ b/src/maidsafe/rudp/core/dispatcher.h
@@ -42,8 +42,6 @@ class Dispatcher {
 
   void SetConnectionManager(ConnectionManager* connection_manager);
 
-  size_t use_count() const { return use_count_.use_count()-1; }
-
   // Add a socket. Returns a new unique id for the socket.
   uint32_t AddSocket(Socket* socket);
 
@@ -59,8 +57,6 @@ class Dispatcher {
   Dispatcher(const Dispatcher&);
   Dispatcher& operator=(const Dispatcher&);
 
-  std::mutex mutex_;
-  std::shared_ptr<int> use_count_;
   ConnectionManager* connection_manager_;
 };
 

--- a/src/maidsafe/rudp/parameters.cc
+++ b/src/maidsafe/rudp/parameters.cc
@@ -24,7 +24,7 @@ namespace maidsafe {
 
 namespace rudp {
 
-uint32_t Parameters::thread_count(2);
+uint32_t Parameters::thread_count(1);
 int Parameters::max_transports(10);
 const uint32_t Parameters::maximum_segment_size(16);
 uint32_t Parameters::default_window_size(4*Parameters::maximum_segment_size);

--- a/src/maidsafe/rudp/transport.h
+++ b/src/maidsafe/rudp/transport.h
@@ -127,6 +127,8 @@ class Transport : public std::enable_shared_from_this<Transport> {
                                     const boost::asio::ip::udp::endpoint& bootstrap_endpoint,
                                     const boost::posix_time::time_duration& lifespan);
   void DetectNatType(NodeId const& peer_id);
+  
+  void DoClose(std::promise<void>& done);
 
   void DoConnect(const NodeId& peer_id, const EndpointPair& peer_endpoint_pair,
                  const std::string& validation_data);


### PR DESCRIPTION
Ok, this is a fairly breaking change to how RUDP works in that ASIO worker threads decreases to 1, and therefore all concurrency within RUDP ceases, and therefore the cause of this bug where Socket was being destroyed concurrently to its use in other threads goes away. The other change is I ripped out my previous remedial work in making Multiplexer reference count deleted, because it was obviously obscuring the problem rather than fixing it.

I soak tested this last night and it hanged exactly once which may or may not be important - out of 500 iterations, that's a hang rate of 0.2%, and could be a false positive. The removal of the remedial work has introduced lots of ThreadSanitiser fails, this is a good thing and I'll try to figure out the new cause. Various tests still sporadically fail, but this branch doesn't have my increased timeouts, so that is expected.

So, if you start seeing hangs after applying this patch, get back to me :) Otherwise it probably fixes more problems than it causes, and therefore is an improvement.
