### PR TITLE
Fixes deadlock caused by blocking Transport::Close()

### DIFF
--- a/src/maidsafe/rudp/transport.cc
+++ b/src/maidsafe/rudp/transport.cc
@@ -263,8 +263,6 @@ void Transport::Close() {
     connection_manager_->Close();
   if (multiplexer_) {
     strand_.post(std::bind(&Multiplexer::Close, multiplexer_));
-    while (IsValid(multiplexer_->external_endpoint()))
-      boost::this_thread::yield();
   }
 }
 


### PR DESCRIPTION
I must say I am not sure why the block was there. What
the code did, it sent (as a job to another thread [1])
close request to the multiplexer and then blocked till
the multiplexer finished. As said, the code was probably
there to fix something, but it wasn't a correct fix
so if it breaks something I'll deal with it differently.
On first glance I didn't see a problem with removing it
since lifetime of the multiplexer is preserved using
a shared_pointer in the callback to the Multiplexer::Close()
metond, and the method doesn't seem to access anything
in this Transport object.

[1] Since there were only two threads active, we were
in one of them and the other one was blocked by our
mutex, the call to Multiplexer::Close was never
executed.
